### PR TITLE
Lv1-4 테스트 코드 퀴즈 - 컨트롤러 테스트의 이해

### DIFF
--- a/src/test/java/org/example/expert/domain/todo/controller/TodoControllerTest.java
+++ b/src/test/java/org/example/expert/domain/todo/controller/TodoControllerTest.java
@@ -35,9 +35,9 @@ class TodoControllerTest {
         // given
         long todoId = 1L;
         String title = "title";
-        AuthUser authUser = new AuthUser(1L, "email", UserRole.USER);
+        AuthUser authUser = new AuthUser(1L, "email", "tester1", UserRole.USER);
         User user = User.fromAuthUser(authUser);
-        UserResponse userResponse = new UserResponse(user.getId(), user.getEmail());
+        UserResponse userResponse = new UserResponse(user.getId(), user.getEmail(), user.getNickname());
         TodoResponse response = new TodoResponse(
                 todoId,
                 title,
@@ -69,9 +69,9 @@ class TodoControllerTest {
 
         // then
         mockMvc.perform(get("/todos/{todoId}", todoId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(HttpStatus.OK.name()))
-                .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.code").value(HttpStatus.BAD_REQUEST.value()))
                 .andExpect(jsonPath("$.message").value("Todo not found"));
     }
 }


### PR DESCRIPTION
> void todo_단건_조회_시_todo가_존재하지_않아_예외가_발생한다()
- todoId = 1 조회 시 InvalidRequestException 발생하는 테스트 코드에서
- 예외 발생 시 현재 코드의 경우 GlobalExceptionHandler 에서 "InvalidRequestException" 는 모두 Bad_Request 로 처리하도록 구현되어 있으므로,
- 해당 예외 발생 시 Bad_Request 값을 가져오도록 코드 수정

> void todo_단건_조회에_성공한다()
- AuthUser, UserResponse 에 nickname 필드가 추가됨에 따라 해당 테스트가 정상 동작할 수 있도록 nickanme 값 추가