### PR TITLE
Lv2-8 QueryDSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,12 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/expert/config/JPAConfiguration.java
+++ b/src/main/java/org/example/expert/config/JPAConfiguration.java
@@ -1,0 +1,20 @@
+package org.example.expert.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JPAConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
@@ -8,18 +8,17 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
-public interface TodoRepository extends JpaRepository<Todo, Long> {
+public interface TodoRepository extends JpaRepository<Todo, Long>, TodoRepositoryCustom {
 
     // 조건이 없을 경우 - 전체 조회 (최신 수정일 순 정렬)
     @Query("SELECT t FROM Todo t LEFT JOIN FETCH t.user u ORDER BY t.modifiedAt DESC")
     Page<Todo> findAllByOrderByModifiedAtDesc(Pageable pageable);
 
-    @Query("SELECT t FROM Todo t " +
-            "LEFT JOIN t.user " +
-            "WHERE t.id = :todoId")
-    Optional<Todo> findByIdWithUser(@Param("todoId") Long todoId);
+
+    // QueryDSL 로 대체
+//    @Query("SELECT t FROM Todo t LEFT JOIN t.user WHERE t.id = :todoId")
+//    Optional<Todo> findByIdWithUser(@Param("todoId") Long todoId);
 
     // weather, start, end 조건이 있을 경우
     @Query("SELECT t FROM Todo t JOIN FETCH t.user WHERE t.weather = :weather AND t.modifiedAt BETWEEN :start AND :end")

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustom.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.example.expert.domain.todo.repository;
+
+import org.example.expert.domain.todo.entity.Todo;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface TodoRepositoryCustom {
+    Optional<Todo> findByIdWithUser(@Param("todoId") Long todoId);
+}

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryImpl.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryImpl.java
@@ -1,0 +1,32 @@
+package org.example.expert.domain.todo.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.todo.entity.QTodo;
+import org.example.expert.domain.todo.entity.Todo;
+import org.example.expert.domain.user.entity.QUser;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class TodoRepositoryImpl implements TodoRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<Todo> findByIdWithUser(Long todoId) {
+
+        QTodo todo = QTodo.todo; // Q타입 클래스 -> Todo
+        QUser user = QUser.user; // Q타입 클래스 -> User
+
+        Todo result = jpaQueryFactory
+                .selectFrom(todo) // select * from todos
+                .join(todo.user, user) // join users on todo.user_id = users.id
+                .fetchJoin() // join -> join fetch 변경 -> N+1 이슈 방지
+                .where(todo.id.eq(todoId)) // where todo.id =?
+                .fetchOne(); // limit 1 -> 단건 조회
+
+
+        return Optional.ofNullable(result); // Optional -> null 가능성이 있어서 Optional 로 감싼 후 반환
+    }
+}


### PR DESCRIPTION
> build.gradle
- QueryDSL 의존성 추가 -> JPAQueryFactory 사용
- annotationProcessor 설정 추가 -> Q타입 클래스 자동 생성

> JPAConfiguration.java
- QueryDSL 사용을 위해 JPAQueryFactory 를 Bean 으로 등록

> TodoRepositoryCustom.java
- QueryDSL 을 사용할 커스텀 메서드를 담은 인터페이스 생성
- TodoRepository.java 에 구현된 findByIdWithUser() 메서드 를 해당 클래스로 이동

> TodoRepositoryImpl.java
- findByIdWithUser() > QueryDSL 기반 로직 구현

> TodoRepository.java
- TodoRepositoryCustom > 상속 추가
- 기존 findByIdWithUser() > 주석 처리 (QueryDSL 로직으로 대체)